### PR TITLE
:nail_care: Evitar error si alguien del equipo no tiene foto

### DIFF
--- a/components/Equipo/Perfil.vue
+++ b/components/Equipo/Perfil.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="perfil">
     <NuxtLink :to="`/equipo/${miembro.slug}`">
-      <EnflujoImagen
-        class="foto"
+      <EnflujoImagen v-if="miembro.foto && miembro.foto.id"
+        class="foto" 
         :class="!miembro.activo ? 'inactivo' : ''"
         :imgId="miembro.foto.id"
         ancho="200"


### PR DESCRIPTION
Actualmente si se crea un perfil de un participante sin foto la página falla. Sugiero este cambio para evitarlo, a menos que queramos obligar a la gente a poner una foto. En ese caso habría que especificarlo en el CMS.